### PR TITLE
Include tests in gem

### DIFF
--- a/rak.gemspec
+++ b/rak.gemspec
@@ -12,7 +12,8 @@ Gem::Specification.new do |s|
   END
   s.email = %q{dan@fluentradical.com}
   s.executables = ["rak"]
-  s.files = ["History.txt", "Manifest.txt", "README.txt", "bin/rak", "lib/rak.rb", "spec/rak_spec.rb", "spec/help_spec.rb"]
+  s.files = ["History.txt", "Manifest.txt", "README.txt", "bin/rak", "lib/rak.rb"]
+  s.files += Dir["spec/**/*"].select { |f| not File.symlink?(f) }
   s.homepage = %q{http://rak.rubyforge.org}
   s.require_paths = ["lib"]
   s.rubyforge_project = %q{rak}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,14 @@ require "pathname"
 HERE = Pathname(__FILE__).parent.expand_path
 require HERE.join("../lib/rak").to_s
 
+# Symlinks can't be shipped in the gem
+if not File.symlink?('spec/example/ln_dir')
+  File.symlink('_darcs/', 'spec/example/ln_dir')
+end
+if not File.symlink?('spec/example/corge.rb')
+  File.symlink('_darcs/corge.rb', 'spec/example/corge.rb')
+end
+
 class String
   def shell_escape
     return "''" if empty?


### PR DESCRIPTION
It'd be useful to be able to run the tests from the gem.

It looks like gem converts symlinks to normal files (is there a way to turn that off?) so this re-creates the symlinks in `spec_helper` if they are missing.
